### PR TITLE
fix: run containers as root to fix volume permission denied

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
 services:
   geth:
     image: ${GETH_IMAGE}
+    user: "0"
     ports:
       # geth http rpc
       - "8545:8545"
@@ -31,6 +32,7 @@ services:
     depends_on:
       - geth
     image: ${NODE_IMAGE}
+    user: "0"
     ports:
       # node rpc
       - "9545:9545"


### PR DESCRIPTION
## Summary
- Add `user: "0"` to both geth and node services to fix `/data` volume write permission denied error

## Test plan
- [ ] Verify `docker compose up -d` starts without permission errors
- [ ] Verify geth creates `/data/config.toml` successfully